### PR TITLE
Adding support for SMB file shares

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function resolver (bower) {
   return {
 
     match: function (source) {
-        if (['.', '/', '~'].indexOf(source.charAt(0)) === -1) return false;
+        if (['.', '/', '~', '\\'].indexOf(source.charAt(0)) === -1) return false;
         return fs.isDirectoryAsync(path.resolve(source))
         .catch(function() {
             return false;


### PR DESCRIPTION
Currently, if a user specifies an SMB file share path, bower throws an error message:

**bower.json:** 
`"my.package": "\\\\servicerepo\\files\\my.package#~2.0.81"`

**Error:**
`bower my.package#~2.0.81     ENORESTARGET File system sources can't resolve targets`

This can be easily solved by improving the match function of this resolver.